### PR TITLE
XE5+ changes

### DIFF
--- a/src/DataSetUtils.pas
+++ b/src/DataSetUtils.pas
@@ -7,7 +7,7 @@ uses DB, SysUtils;
 type
   TDataSetUtils = class
   public
-    class function CreateField(DataSet: TDataSet; FieldType: TFieldType; const FieldName: string = '';ASize: Integer=0): TField;
+    class function CreateField(DataSet: TDataSet; FieldType: TFieldType; const FieldName: string = '';ASize: Integer=0; const displayName: string=''): TField;
     class function CreateDataSetField(DataSet: TDataSet; const FieldName: string): TDataSetField;
   end;
 
@@ -21,19 +21,21 @@ begin
 end;
 
 class function TDataSetUtils.CreateField(DataSet: TDataSet;
-  FieldType: TFieldType; const FieldName: string; ASize: Integer): TField;
+  FieldType: TFieldType; const FieldName: string; ASize: Integer; const displayName: string): TField;
 begin
     Result:= DefaultFieldClasses[FieldType].Create(DataSet);
     Result.FieldName:= FieldName;
     if Result.FieldName = '' then
       Result.FieldName:= 'Field' + IntToStr(DataSet.FieldCount +1);
+    if(displayName <> '') then
+      result.DisplayLabel := displayName;
     Result.FieldKind := fkData;
     Result.DataSet:= DataSet;
     Result.Name:= DataSet.Name + Result.FieldName;
     Result.Size := ASize;
 
     if (FieldType = ftString) and (ASize <= 0) then
-      raise Exception.CreateFmt('Size não definido para o campo "%s".',[FieldName]);
+      raise Exception.CreateFmt('Size nÃ£o definido para o campo "%s".',[FieldName]);
 end;
 
 end.

--- a/src/JsonToDataSetConverter.pas
+++ b/src/JsonToDataSetConverter.pas
@@ -11,15 +11,17 @@ type
     class procedure SetFieldValue(AField: TField; AValue: ISuperObject);
 
     class procedure ExtractFields(ADataSet: TDataSet; AObject: ISuperObject);
+    class procedure ExtractStructure(ADataSet: TDataSet; AObject: ISuperObject; tableNode, titleNode: string);
 
     class function SuperTypeToFieldType(ASuperType: TSuperType): TFieldType;
     class function SuperTypeToFieldSize(ASuperType: TSuperType): Integer;
   public
-    class procedure UnMarshalToDataSet(ADataSet: TDataSet; AJson: string);overload;
-    class procedure UnMarshalToDataSet(ADataSet: TDataSet; AObject: ISuperObject);overload;
+    class procedure UnMarshalToDataSet(ADataSet: TClientDataSet; AJson: string);
+    class procedure ToDataSet(ADataSet: TClientDataSet; AObject: ISuperObject);
 
     class function CreateDataSetMetadata(AJson: string): TClientDataSet; overload;
     class function CreateDataSetMetadata(AObject: ISuperObject): TClientDataSet; overload;
+    class function CreateDataSetMetadata(AObject: ISuperObject; table, structure: string): TClientDataSet; overload;
   end;
 
 implementation
@@ -83,6 +85,26 @@ begin
   Result.CreateDataSet;
 end;
 
+class function TJsonToDataSetConverter.CreateDataSetMetadata(AObject: ISuperObject; table, structure: string): TClientDataSet;
+var
+  vArray: TSuperArray;
+begin
+  Result := TClientDataSet.Create(nil);
+
+  if AObject.IsType(stArray) then
+  begin
+    vArray := AObject.O[table].AsArray;
+
+    ExtractStructure(Result, AObject, table, structure);
+  end
+  else
+  begin
+    ExtractStructure(Result, AObject, table, structure);
+  end;
+  if Result.Fields.Count > 0 then
+    Result.CreateDataSet;
+end;
+
 class procedure TJsonToDataSetConverter.ExtractFields(ADataSet: TDataSet;AObject: ISuperObject);
 var
   vIterator: TSuperObjectIter;
@@ -114,32 +136,75 @@ begin
   end;
 end;
 
+class procedure TJsonToDataSetConverter.ExtractStructure(ADataSet: TDataSet; AObject: ISuperObject; tableNode, titleNode: string);
+
+var
+  vIterator: TSuperObjectIter;
+  vNestedField: TDataSetField;
+  vArray: TSuperArray;
+  table: TSuperArray;
+  I: Integer;
+begin
+  i:= 0;
+  table:= AObject.o[tableNode].AsArray;
+  if SuperObject.ObjectFindFirst(table[0], vIterator) then
+  begin
+    try
+      repeat
+        if (vIterator.val.IsType(stArray)) then
+        begin
+          vNestedField := TDataSetUtils.CreateDataSetField(ADataSet, vIterator.key);
+
+          vArray := vIterator.val.AsArray;
+          if (vArray.Length > 0) then
+          begin
+            ExtractFields(vNestedField.NestedDataSet, vArray[0]);
+          end;
+        end
+        else
+        begin
+          TDataSetUtils.CreateField(ADataSet, SuperTypeToFieldType(vIterator.val.DataType), vIterator.key,
+          SuperTypeToFieldSize(vIterator.val.DataType), AObject.o[titleNode].S[vIterator.key]);
+        end;
+      until not SuperObject.ObjectFindNext(vIterator);
+    finally
+      SuperObject.ObjectFindClose(vIterator);
+    end;
+  end;
+
+end;
+
 class procedure TJsonToDataSetConverter.SetFieldValue(AField: TField;AValue: ISuperObject);
 var
   vFieldName: string;
-  vNestedDataSet: TDataSet;
+  vNestedDataSet: TClientDataSet;
 begin
-  vFieldName := AField.FieldName;
-  case AField.DataType of
-    ftSmallint, ftInteger, ftWord, ftLargeint: AField.AsInteger := AValue.AsInteger;
-    ftFloat, ftCurrency, ftBCD, ftFMTBcd: AField.AsFloat := AValue.AsDouble;
-    ftBoolean: AField.AsBoolean := AValue.AsBoolean;
-    ftDate, ftTime, ftDateTime, ftTimeStamp: AField.AsDateTime := AValue.AsDouble;
-    ftDataSet:  begin
-                  vNestedDataSet := TDataSetField(AField).NestedDataSet;
+    vFieldName := AField.FieldName;
+    if (AValue.IsType(stNull)) then
+      begin
+        vNestedDataSet := nil;
+        exit;
+      end;
+    case AField.DataType of
+      ftSmallint, ftInteger, ftWord, ftLargeint: AField.AsInteger := AValue.AsInteger;
+      ftFloat, ftCurrency, ftBCD, ftFMTBcd: AField.AsFloat := AValue.AsDouble;
+      ftBoolean: AField.AsBoolean := AValue.AsBoolean;
+      ftDate, ftTime, ftDateTime, ftTimeStamp: AField.AsDateTime := AValue.AsDouble;
+      ftDataSet:  begin
+                    vNestedDataSet := TClientDataSet( TDataSetField(AField).NestedDataSet);
 
-                  UnMarshalToDataSet(vNestedDataSet, AValue);
-                end;
-  else
-    AField.AsString := AValue.AsString;
-  end;
+                    ToDataSet(vNestedDataSet, AValue);
+                  end;
+    else
+      AField.AsString := AValue.AsString;
+    end;
 end;
 
 class function TJsonToDataSetConverter.SuperTypeToFieldSize(ASuperType: TSuperType): Integer;
 begin
   Result := 0;
 
-  if (ASuperType = stString) then
+  if (ASuperType = stNull) or (ASuperType = stString) then	// Some fields return as null
   begin
     Result := 255;
   end;
@@ -155,16 +220,19 @@ begin
     stObject: Result := ftDataSet;
     stArray: Result := ftDataSet;
     stString: Result := ftString;
+    stNull: Result:= ftstring;	// Rather than fail with an unknown type
   else
     Result := ftUnknown;
   end;
 end;
 
-class procedure TJsonToDataSetConverter.UnMarshalToDataSet(ADataSet: TDataSet;AObject: ISuperObject);
+class procedure TJsonToDataSetConverter.ToDataSet(ADataSet: TClientDataSet; AObject: ISuperObject);
 var
   i: Integer;
   vArray: TSuperArray;
 begin
+  if (ADataSet.FieldDefs.Count = 0) then // Check for whether any data is returned
+    EXIT;
   ADataSet.DisableControls;
   try
     if AObject.IsType(stArray) then
@@ -187,13 +255,13 @@ begin
   ADataSet.First;
 end;
 
-class procedure TJsonToDataSetConverter.UnMarshalToDataSet(ADataSet: TDataSet; AJson: string);
+class procedure TJsonToDataSetConverter.UnMarshalToDataSet(ADataSet: TClientDataSet; AJson: string);
 var
   AObject: ISuperObject;
 begin
   AObject := SuperObject.SO(AJson);
 
-  UnMarshalToDataSet(ADataSet, AObject);
+  ToDataSet(ADataSet, AObject);
 end;
 
 end.


### PR DESCRIPTION
1. Rename TRestClient to TJsonRestClient to avoid collisions with native TRestClient
2. Introduce Post functions to support returning of data sets
3. Introduce Display name parameter to make created datasets  with user friendly titles
4. Fall back to stNull to ftString instead of ftUnknown
5. Expand the use of superobject since native Delphi serialization/Json handling is not as robust 