### PR TITLE
Implementes Async requests for WinHTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ unittest/UnitTest.exe
 unittest/UnitTest.map
 unittest/UnitTest.stat
 unittest/target
+unittest/dunit.ini
 packages/D7/D7_RestApi.dsk
 packages/D7/D7_RestApi.res
 packages/XE/DelphiXE_RestApi.res

--- a/java-rest-server/src/main/java/br/com/fabriciodev/rest/controller/AsyncController.java
+++ b/java-rest-server/src/main/java/br/com/fabriciodev/rest/controller/AsyncController.java
@@ -1,0 +1,17 @@
+package br.com.fabriciodev.rest.controller;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/async")
+public class AsyncController {
+	@GET
+	@Produces({ MediaType.TEXT_PLAIN })
+	public String longRunningMethod() throws InterruptedException {
+		Thread.sleep(5000);
+		return "ok";
+	}
+}

--- a/src/HttpConnection.pas
+++ b/src/HttpConnection.pas
@@ -26,6 +26,8 @@ type
 
   THTTPConnectionLostEvent = procedure(AException: Exception; var ARetryMode: THTTPRetryMode) of object;
 
+  TAsyncRequestProcessEvent = reference to procedure(var Cancel: Boolean);
+
   EHTTPVerifyCertError = class(Exception) end;
 
   TProxyCredentials = class(TComponent)
@@ -85,6 +87,7 @@ type
     function SetHeaders(AHeaders: TStrings): IHttpConnection;
     function ConfigureTimeout(const ATimeOut: TTimeOut): IHttpConnection;
     function ConfigureProxyCredentials(AProxyCredentials: TProxyCredentials): IHttpConnection;
+    function SetOnAsyncRequestProcess(const Value: TAsyncRequestProcessEvent): IHttpConnection;
 
     procedure Get(AUrl: string; AResponse: TStream);
     procedure Post(AUrl: string; AContent, AResponse: TStream);
@@ -99,8 +102,8 @@ type
 
     procedure SetEnabledCompression(const Value: Boolean);
     procedure SetVerifyCert(const Value: boolean);
-    
-    procedure SetAsync(const Value: Boolean);
+
+    function SetAsync(const Value: Boolean): IHttpConnection;
     procedure CancelRequest;
 
     property ResponseCode: Integer read GetResponseCode;

--- a/src/HttpConnection.pas
+++ b/src/HttpConnection.pas
@@ -99,6 +99,9 @@ type
 
     procedure SetEnabledCompression(const Value: Boolean);
     procedure SetVerifyCert(const Value: boolean);
+    
+    procedure SetAsync(const Value: Boolean);
+    procedure CancelRequest;
 
     property ResponseCode: Integer read GetResponseCode;
     property ResponseHeader[const Header: string]: string read GetResponseHeader;
@@ -108,7 +111,6 @@ type
     function GetOnConnectionLost: THTTPConnectionLostEvent;
     procedure SetOnConnectionLost(AConnectionLostEvent: THTTPConnectionLostEvent);
     property OnConnectionLost: THTTPConnectionLostEvent read GetOnConnectionLost write SetOnConnectionLost;
-
   end;
 
 implementation

--- a/src/HttpConnectionIndy.pas
+++ b/src/HttpConnectionIndy.pas
@@ -17,6 +17,7 @@ type
     FIdHttp: TIdHTTP;
     FEnabledCompression: Boolean;
     FVerifyCert: boolean;
+    procedure CancelRequest;
     function IdSSLIOHandlerSocketOpenSSL1VerifyPeer(Certificate: TIdX509;
       AOk: Boolean; ADepth, AError: Integer): Boolean;
   public
@@ -45,14 +46,13 @@ type
     procedure SetVerifyCert(const Value: boolean);
     function GetVerifyCert: boolean;
 
-    procedure SetAsync(const Value: Boolean);
-    procedure CancelRequest;
-
+    function SetAsync(const Value: Boolean): IHttpConnection;
     function GetOnConnectionLost: THTTPConnectionLostEvent;
     procedure SetOnConnectionLost(AConnectionLostEvent: THTTPConnectionLostEvent);
 
     function ConfigureTimeout(const ATimeOut: TTimeOut): IHttpConnection;
     function ConfigureProxyCredentials(AProxyCredentials: TProxyCredentials): IHttpConnection;
+    function SetOnAsyncRequestProcess(const Value: TAsyncRequestProcessEvent): IHttpConnection;
   end;
 
 implementation
@@ -319,10 +319,12 @@ begin
   Result := Self;
 end;
 
-procedure THttpConnectionIndy.SetAsync(const Value: Boolean);
+function THttpConnectionIndy.SetAsync(const Value: Boolean): IHttpConnection;
 begin
   if Value then
     raise ENotImplemented.Create('Async requests not implemented for Indy.');
+
+  Result := Self;
 end;
 
 function THttpConnectionIndy.SetContentTypes(AContentTypes: string): IHttpConnection;
@@ -365,6 +367,11 @@ begin
     FIdHttp.Request.CustomHeaders.AddValue(AHeaders.Names[i], AHeaders.ValueFromIndex[i]);
   end;
 
+  Result := Self;
+end;
+
+function THttpConnectionIndy.SetOnAsyncRequestProcess(const Value: TAsyncRequestProcessEvent): IHttpConnection;
+begin
   Result := Self;
 end;
 

--- a/src/HttpConnectionIndy.pas
+++ b/src/HttpConnectionIndy.pas
@@ -321,7 +321,8 @@ end;
 
 procedure THttpConnectionIndy.SetAsync(const Value: Boolean);
 begin
-  raise ENotImplemented.Create('Async requests not implemented for Indy.');
+  if Value then
+    raise ENotImplemented.Create('Async requests not implemented for Indy.');
 end;
 
 function THttpConnectionIndy.SetContentTypes(AContentTypes: string): IHttpConnection;

--- a/src/HttpConnectionIndy.pas
+++ b/src/HttpConnectionIndy.pas
@@ -45,6 +45,9 @@ type
     procedure SetVerifyCert(const Value: boolean);
     function GetVerifyCert: boolean;
 
+    procedure SetAsync(const Value: Boolean);
+    procedure CancelRequest;
+
     function GetOnConnectionLost: THTTPConnectionLostEvent;
     procedure SetOnConnectionLost(AConnectionLostEvent: THTTPConnectionLostEvent);
 
@@ -58,6 +61,10 @@ uses
   ProxyUtils;
 
 { THttpConnectionIndy }
+
+procedure THttpConnectionIndy.CancelRequest;
+begin
+end;
 
 function THttpConnectionIndy.ConfigureProxyCredentials(
   AProxyCredentials: TProxyCredentials): IHttpConnection;
@@ -310,6 +317,11 @@ function THttpConnectionIndy.SetAcceptTypes(AAcceptTypes: string): IHttpConnecti
 begin
   FIdHttp.Request.Accept := AAcceptTypes;
   Result := Self;
+end;
+
+procedure THttpConnectionIndy.SetAsync(const Value: Boolean);
+begin
+  raise ENotImplemented.Create('Async requests not implemented for Indy.');
 end;
 
 function THttpConnectionIndy.SetContentTypes(AContentTypes: string): IHttpConnection;

--- a/src/HttpConnectionWinInet.pas
+++ b/src/HttpConnectionWinInet.pas
@@ -99,9 +99,7 @@ type
     FBasicAuthentication_Password : string;
     FCertificateContext : PCERT_CONTEXT;
     FCertificateCheckAuthority: boolean;
-
     FCertificateIgnoreRevocation: boolean;
-
     FCertificateCheckHostName: boolean;
     FCertificateCheckDate: Boolean;
     FResponseCode : Integer;
@@ -147,8 +145,10 @@ type
     procedure SetVerifyCert(const Value: boolean);
     function GetVerifyCert: boolean;
 
-    procedure SetAsync(const Value: Boolean);
+    function SetAsync(const Value: Boolean): IHttpConnection;
     procedure CancelRequest;
+
+    function SetOnAsyncRequestProcess(const Value: TAsyncRequestProcessEvent): IHttpConnection;
 
     property ResponseErrorStatusText : string read FResponseErrorStatusText write FResponseErrorStatusText;
     property CertificateContext: PCERT_CONTEXT read FCertificateContext write FCertificateContext;
@@ -303,10 +303,12 @@ begin
   Result := Self;
 end;
 
-procedure THttpConnectionWinInet.SetAsync(const Value: Boolean);
+function THttpConnectionWinInet.SetAsync(const Value: Boolean): IHttpConnection;
 begin
   if Value then
     raise ENotImplemented.Create('Async requests not implemented for WinInet.');
+
+  Result := Self;
 end;
 
 function THttpConnectionWinInet.SetContentTypes(AContentTypes: string): IHttpConnection;
@@ -325,6 +327,11 @@ function THttpConnectionWinInet.SetHeaders(AHeaders: TStrings): IHttpConnection;
 begin
   FHeaders.Assign(AHeaders);
 
+  Result := Self;
+end;
+
+function THttpConnectionWinInet.SetOnAsyncRequestProcess(const Value: TAsyncRequestProcessEvent): IHttpConnection;
+begin
   Result := Self;
 end;
 

--- a/src/HttpConnectionWinInet.pas
+++ b/src/HttpConnectionWinInet.pas
@@ -305,7 +305,8 @@ end;
 
 procedure THttpConnectionWinInet.SetAsync(const Value: Boolean);
 begin
-  raise ENotImplemented.Create('Async requests not implemented for WinInet.');
+  if Value then
+    raise ENotImplemented.Create('Async requests not implemented for WinInet.');
 end;
 
 function THttpConnectionWinInet.SetContentTypes(AContentTypes: string): IHttpConnection;

--- a/src/HttpConnectionWinInet.pas
+++ b/src/HttpConnectionWinInet.pas
@@ -123,7 +123,8 @@ type
     function SetAcceptedLanguages(AAcceptedLanguages: string): IHttpConnection;
     function SetContentTypes(AContentTypes: string): IHttpConnection;
     function SetHeaders(AHeaders: TStrings): IHttpConnection;
-	property Headers: TStrings read FHeaders;
+
+    property Headers: TStrings read FHeaders;
 
     procedure Get(AUrl: string; AResponse: TStream);
     procedure Post(AUrl: string; AContent: TStream; AResponse: TStream);
@@ -133,7 +134,6 @@ type
 
     function GetResponseCode: Integer;
     function GetResponseHeader(const Header: string): string;
-
 
     function GetEnabledCompression: Boolean;
     procedure SetEnabledCompression(const Value: Boolean);
@@ -146,6 +146,9 @@ type
 
     procedure SetVerifyCert(const Value: boolean);
     function GetVerifyCert: boolean;
+
+    procedure SetAsync(const Value: Boolean);
+    procedure CancelRequest;
 
     property ResponseErrorStatusText : string read FResponseErrorStatusText write FResponseErrorStatusText;
     property CertificateContext: PCERT_CONTEXT read FCertificateContext write FCertificateContext;
@@ -197,6 +200,10 @@ constructor EInetException.Create(const AErrorMessage: string; const AErrorCode:
 begin
   iFErrorCode := AErrorCode;
   inherited CreateFmt('%s (%d)', [AErrorMessage, iFErrorCode]);
+end;
+
+procedure THttpConnectionWinInet.CancelRequest;
+begin
 end;
 
 function THttpConnectionWinInet.ConfigureProxyCredentials(
@@ -294,6 +301,11 @@ begin
   FAcceptTypes := AAcceptTypes;
   
   Result := Self;
+end;
+
+procedure THttpConnectionWinInet.SetAsync(const Value: Boolean);
+begin
+  raise ENotImplemented.Create('Async requests not implemented for WinInet.');
 end;
 
 function THttpConnectionWinInet.SetContentTypes(AContentTypes: string): IHttpConnection;

--- a/src/RestClient.pas
+++ b/src/RestClient.pas
@@ -691,6 +691,11 @@ begin
   Result := FAcceptTypes;
 end;
 
+function TResource.GetAsync: Boolean;
+begin
+   Result := FAsync;
+end;
+
 function TResource.GetContent: TStream;
 begin
   Result := FContent;
@@ -844,11 +849,6 @@ begin
   end else begin
     Result:=GetasDataSet();
   end;
-end;
-
-function TResource.GetAsync: Boolean;
-begin
-  Result := FAsync;
 end;
 
 function TResource.GetAsDataSet: TDataSet;

--- a/src/RestClient.pas
+++ b/src/RestClient.pas
@@ -70,6 +70,7 @@ type
     FTimeOut: TTimeOut;
     FProxyCredentials: TProxyCredentials;
     FLogin: String;
+    FOnAsyncRequestProcess: TAsyncRequestProcessEvent;
     FPassword: String;
     FOnError: THTTPErrorEvent;
 
@@ -120,10 +121,9 @@ type
 
     function SetCredentials(const ALogin, APassword: String): TRestClient;
 
-    procedure CancelRequest;
-
     property OnConnectionLost: THTTPConnectionLostEvent read GetOnConnectionLost write SetOnConnectionLost;
     property OnError: THTTPErrorEvent read GetOnError write SetOnError;
+    property OnAsyncRequestProcess: TAsyncRequestProcessEvent read FOnAsyncRequestProcess write FOnAsyncRequestProcess;
 
   published
     property ConnectionType: THttpConnectionType read FConnectionType write SetConnectionType;
@@ -266,7 +266,8 @@ end;
 
 destructor TRestClient.Destroy;
 begin
-  CancelRequest;
+  if FHttpConnection <> nil then
+    FHttpConnection.CancelRequest;
   FResources.Free;
   FHttpConnection := nil;
   inherited;
@@ -319,7 +320,8 @@ begin
                    .SetAcceptedLanguages(ResourceRequest.GetAcceptedLanguages)
                    .ConfigureTimeout(FTimeOut)
                    .ConfigureProxyCredentials(FProxyCredentials)
-                   .SetAsync(ResourceRequest.GetAsync);
+                   .SetAsync(ResourceRequest.GetAsync)
+                   .SetOnAsyncRequestProcess(FOnAsyncRequestProcess);
 
     vUrl := ResourceRequest.GetURL;
 
@@ -449,12 +451,6 @@ begin
       FHttpConnection.EnabledCompression := FEnabledCompression;
     end;
   end;
-end;
-
-procedure TRestClient.CancelRequest;
-begin
-  if FHttpConnection <> nil then
-    FHttpConnection.CancelRequest;
 end;
 
 procedure TRestClient.CheckConnection;

--- a/unittest/BaseTestRest.pas
+++ b/unittest/BaseTestRest.pas
@@ -24,6 +24,7 @@ type
     FRestClient: TRestClient;
     FHttpConnectionType: THttpConnectionType;
   protected
+    procedure FreeAndNilRestClient;
     procedure SetUp; override;
     procedure TearDown; override;
   public
@@ -41,12 +42,20 @@ const
 
 implementation
 
+uses
+  System.SysUtils;
+
 { TBaseTestRest }
 
 constructor TBaseTestRest.Create(MethodName: string);
 begin
   inherited;
 
+end;
+
+procedure TBaseTestRest.FreeAndNilRestClient;
+begin
+  FreeAndNil(FRestClient);
 end;
 
 class procedure TBaseTestRest.RegisterTest;
@@ -81,7 +90,7 @@ end;
 
 procedure TBaseTestRest.TearDown;
 begin
-  FRestClient.Free;
+  FreeAndNilRestClient;
   inherited;
 end;
 

--- a/unittest/TestAsync.pas
+++ b/unittest/TestAsync.pas
@@ -8,7 +8,8 @@ type
   TTestAsync = class(TBaseTestRest)
   private
   published
-    procedure GET_CancelRequest;
+    procedure GET_CancelRequestUsingOnAsyncRequestProcessEvent;
+    procedure GET_CancelRequestWhenDestroyingTheRestClientObject;
   end;
 
 implementation
@@ -18,21 +19,38 @@ uses
 
 { TTestAsync }
 
-procedure TTestAsync.GET_CancelRequest;
+procedure TTestAsync.GET_CancelRequestUsingOnAsyncRequestProcessEvent;
 begin
   if RestClient.ConnectionType = hctWinHttp then
-  begin
-    ExpectedException := EAbort;
-
-    TThread.CreateAnonymousThread(
-      procedure
-      begin
-        Sleep(100);
-        RestClient.CancelRequest;
-      end).Start;
-  end
+    ExpectedException := EAbort
   else
     ExpectedException := ENotImplemented;
+
+  RestClient.OnAsyncRequestProcess :=
+    procedure(var Cancel: Boolean)
+    begin
+      Cancel := True;
+    end;
+
+  RestClient.Resource(CONTEXT_PATH + 'async')
+            .Accept('text/plain')
+            .Async
+            .GET();
+end;
+
+procedure TTestAsync.GET_CancelRequestWhenDestroyingTheRestClientObject;
+begin
+  if RestClient.ConnectionType = hctWinHttp then
+    ExpectedException := EAbort
+  else
+    ExpectedException := ENotImplemented;
+
+  TThread.CreateAnonymousThread(
+    procedure
+    begin
+      Sleep(50);
+      FreeAndNilRestClient;
+    end).Start;
 
   RestClient.Resource(CONTEXT_PATH + 'async')
             .Accept('text/plain')

--- a/unittest/TestAsync.pas
+++ b/unittest/TestAsync.pas
@@ -1,0 +1,47 @@
+unit TestAsync;
+
+interface
+
+uses BaseTestRest;
+
+type
+  TTestAsync = class(TBaseTestRest)
+  private
+  published
+    procedure GET_CancelRequest;
+  end;
+
+implementation
+
+uses
+  System.Classes, System.SysUtils, HttpConnection;
+
+{ TTestAsync }
+
+procedure TTestAsync.GET_CancelRequest;
+begin
+  if RestClient.ConnectionType = hctWinHttp then
+  begin
+    ExpectedException := EAbort;
+
+    TThread.CreateAnonymousThread(
+      procedure
+      begin
+        Sleep(100);
+        RestClient.CancelRequest;
+      end).Start;
+  end
+  else
+    ExpectedException := ENotImplemented;
+
+  RestClient.Resource(CONTEXT_PATH + 'async')
+            .Accept('text/plain')
+            .Async
+            .GET();
+end;
+
+initialization
+  TTestAsync.RegisterTest;
+
+end.
+

--- a/unittest/TestRestClient.pas
+++ b/unittest/TestRestClient.pas
@@ -60,8 +60,10 @@ type
     procedure SetVerifyCert(const Value: boolean);
     function GetVerifyCert: boolean;virtual;abstract;
 
-    procedure SetAsync(const Value: Boolean);virtual;abstract;
+    function SetAsync(const Value: Boolean): IHttpConnection; virtual; abstract;
     procedure CancelRequest;
+
+    function SetOnAsyncRequestProcess(const Value: TAsyncRequestProcessEvent): IHttpConnection;
   end;
 
 { TTestRestClient }
@@ -137,6 +139,11 @@ end;
 function TStubConnection.GetOnConnectionLost: THTTPConnectionLostEvent;
 begin
 
+end;
+
+function TStubConnection.SetOnAsyncRequestProcess(const Value: TAsyncRequestProcessEvent): IHttpConnection;
+begin
+  Result := Self;
 end;
 
 procedure TStubConnection.SetOnConnectionLost(

--- a/unittest/TestRestClient.pas
+++ b/unittest/TestRestClient.pas
@@ -53,15 +53,15 @@ type
 
     procedure SetEnabledCompression(const Value: Boolean);virtual;abstract;
 
-
     function GetOnConnectionLost: THTTPConnectionLostEvent;
     procedure SetOnConnectionLost(AConnectionLostEvent: THTTPConnectionLostEvent);
     property OnConnectionLost: THTTPConnectionLostEvent read GetOnConnectionLost write SetOnConnectionLost;
 
     procedure SetVerifyCert(const Value: boolean);
-    function GetVerifyCert: boolean;
+    function GetVerifyCert: boolean;virtual;abstract;
 
-  public
+    procedure SetAsync(const Value: Boolean);virtual;abstract;
+    procedure CancelRequest;
   end;
 
 { TTestRestClient }
@@ -127,14 +127,14 @@ begin
   CheckTrue(Supports(FRest.UnWrapConnection, IStubConnection));
 end;
 
-{ TStubConnection }
-
-function TStubConnection.GetOnConnectionLost: THTTPConnectionLostEvent;
+procedure TStubConnection.CancelRequest;
 begin
 
 end;
 
-function TStubConnection.GetVerifyCert: boolean;
+{ TStubConnection }
+
+function TStubConnection.GetOnConnectionLost: THTTPConnectionLostEvent;
 begin
 
 end;

--- a/unittest/UnitTest.dpr
+++ b/unittest/UnitTest.dpr
@@ -39,7 +39,8 @@ uses
   TestDBXJsonUtils in 'TestDBXJsonUtils.pas',
   TestDbxJsonMarshal in 'TestDbxJsonMarshal.pas',
   TestRestUtils in 'TestRestUtils.pas',
-  TestSuperobject in 'TestSuperobject.pas';
+  TestSuperobject in 'TestSuperobject.pas',
+  TestAsync in 'TestAsync.pas';
 
 {$R *.RES}
 

--- a/unittest/UnitTest.dproj
+++ b/unittest/UnitTest.dproj
@@ -82,6 +82,7 @@
         <DCCReference Include="TestDbxJsonMarshal.pas"/>
         <DCCReference Include="TestRestUtils.pas"/>
         <DCCReference Include="TestSuperobject.pas"/>
+        <DCCReference Include="TestAsync.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>


### PR DESCRIPTION
This allows a long running request to be cancelled and also to update the UI without using a thread.

I'm making requests to a longpoll server and the request can take up to 60 seconds and if I close the application it waits until the request is finished so it might take up to 60 seconds to close.

Some details about the implementation:

- When the request is cancelled an `EAbort` exception is raised.
- There is a new `OnAsyncRequestProcess` event in `TRestClient` that is called every second (min wait time for WinHTTP)
- When you free the TRestClient, if Async is True and there is a running request it is cancelled before freeing the connection


Here's an exemple of use:

```Delphi
  RestClient.OnAsyncRequestProcess :=
    procedure(var Cancel: Boolean)
    begin
      Cancel := True; // Set cancel to true to abort the request
    end;

// This will raise an EAbort if the request is canceled 
 RestClient.Resource(CONTEXT_PATH + 'async')
            .Accept('text/plain')
            .Async
            .GET();
```