### PR TITLE
Delphi 2007 backwards compatibility fix

### DIFF
--- a/src/DbxJsonUtils.pas
+++ b/src/DbxJsonUtils.pas
@@ -4,10 +4,10 @@ interface
 
 uses SysUtils, DateUtils;
 
-type
 {$I DelphiRest.inc}
 
 {$IFDEF USE_GENERICS}
+type
   TJsonAttribute = class(TCustomAttribute)
   private
     FName: string;


### PR DESCRIPTION
Moved type to inside IFDEF block due to compiler error with D2007