### PR TITLE
Check if proxy values exists before reading from registry

### DIFF
--- a/src/ProxyUtils.pas
+++ b/src/ProxyUtils.pas
@@ -31,7 +31,8 @@ begin
     try
       Reg.RootKey := HKEY_CURRENT_USER;
       Reg.OpenKey(INTERNET_SETTINGS, false);
-      Result := Reg.ReadString(Value);
+      if Reg.ValueExists(Value) then
+        Result := Reg.ReadString(Value);
     finally
       Reg.Free;
     end
@@ -41,22 +42,23 @@ begin
   end;
 end;
 
-function ReadIntegerRegistryValue(const Value: string): integer;
+function ReadIntegerRegistryValue(const Value: string): Integer;
 var
   Reg: TRegistry;
 begin
+  Result := 0;
   try
     Reg := TRegistry.Create;
     try
       Reg.RootKey := HKEY_CURRENT_USER;
       Reg.OpenKey(INTERNET_SETTINGS, false);
-      Result := Reg.ReadInteger(Value);
+      if Reg.ValueExists(Value) then
+        Result := Reg.ReadInteger(Value);
     finally
       Reg.Free;
     end
   except
-    on E: ERegistryException do
-      Result := 0;
+    on E: ERegistryException do;
   end;
 end;
 

--- a/src/ProxyUtils.pas
+++ b/src/ProxyUtils.pas
@@ -26,20 +26,14 @@ function ReadStringRegistryValue(const Value: string): string;
 var
   Reg: TRegistry;
 begin
+  Reg := TRegistry.Create;
   try
-    Reg := TRegistry.Create;
-    try
-      Reg.RootKey := HKEY_CURRENT_USER;
-      Reg.OpenKey(INTERNET_SETTINGS, false);
-      if Reg.ValueExists(Value) then
-        Result := Reg.ReadString(Value);
-    finally
-      Reg.Free;
-    end
-  except
-    on E: ERegistryException do
-      Result := '';
-  end;
+    Reg.RootKey := HKEY_CURRENT_USER;
+    if Reg.OpenKeyReadOnly(INTERNET_SETTINGS) and Reg.ValueExists(Value) then
+      Result := Reg.ReadString(Value);
+  finally
+    Reg.Free;
+  end
 end;
 
 function ReadIntegerRegistryValue(const Value: string): Integer;
@@ -47,19 +41,14 @@ var
   Reg: TRegistry;
 begin
   Result := 0;
+  Reg := TRegistry.Create;
   try
-    Reg := TRegistry.Create;
-    try
-      Reg.RootKey := HKEY_CURRENT_USER;
-      Reg.OpenKey(INTERNET_SETTINGS, false);
-      if Reg.ValueExists(Value) then
-        Result := Reg.ReadInteger(Value);
-    finally
-      Reg.Free;
-    end
-  except
-    on E: ERegistryException do;
-  end;
+    Reg.RootKey := HKEY_CURRENT_USER;
+    if Reg.OpenKeyReadOnly(INTERNET_SETTINGS) and Reg.ValueExists(Value) then
+      Result := Reg.ReadInteger(Value);
+  finally
+    Reg.Free;
+  end
 end;
 
 function ProxyActive: Boolean;


### PR DESCRIPTION
This ERegistryException is handled but it shows up in our logs, also it is not a good idea to use exceptions flow control.