### PR TITLE
Adding return type to the Generic Post

### DIFF
--- a/src/RestClient.pas
+++ b/src/RestClient.pas
@@ -209,6 +209,7 @@ type
     {$IFDEF SUPPORTS_GENERICS}
     function Get<T>(): T;overload;
     function Post<T>(Entity: TObject): T;overload;
+    function Post<T,RT>(Entity: TObject): RT;overload;
     function Put<T>(Entity: TObject): T;overload;
     function Patch<T>(Entity: TObject): T;overload;
     {$ELSE}
@@ -746,6 +747,20 @@ begin
     Result := TJsonUtil.UnMarshal<T>(vResponse)
   else
     Result := Default(T);
+end;
+
+function TResource.Post<T,RT>(Entity: TObject): RT;
+var
+  vResponse: string;
+begin
+  SetContent(Entity);
+
+  vResponse := FRestClient.DoRequest(METHOD_POST, Self);
+
+  if trim(vResponse) <> '' then
+    Result := TJsonUtil.UnMarshal<RT>(vResponse)
+  else
+    Result := Default(RT);
 end;
 
 function TResource.Put<T>(Entity: TObject): T;


### PR DESCRIPTION
For my API, I'm returning a string with important information.

With this change I can do the following:
```
FErrorMessage := RestClient.Resource(restUrl)

                              .Accept(RestUtils.MediaType_Json)

                              .ContentType(RestUtils.MediaType_Json)

                              .Post<TPdfMergeDto, string>(MergeDto);
```