### PR TITLE
Removed old no longer working temp fix for TList serialization in superobject

### DIFF
--- a/lib/superobject/superobject.pas
+++ b/lib/superobject/superobject.pas
@@ -803,7 +803,7 @@ type
     constructor Create; virtual;
     destructor Destroy; override;
     function FromJson(TypeInfo: PTypeInfo; const obj: ISuperObject; var Value: TValue): Boolean; virtual;
-    function ToJson(var value: TValue; const index: ISuperObject; _listCount: integer=-1; field: TRttiField = nil): ISuperObject; virtual;
+    function ToJson(var value: TValue; const index: ISuperObject; field: TRttiField = nil): ISuperObject; virtual;
     function AsType<T>(const obj: ISuperObject): T;
     function AsJson<T>(const obj: T; const index: ISuperObject = nil): ISuperObject;
   end;
@@ -6926,7 +6926,7 @@ begin
     Result := False;
 end;
 
-function TSuperRttiContext.ToJson(var value: TValue; const index: ISuperObject; _listCount: integer; field: TRttiField): ISuperObject;
+function TSuperRttiContext.ToJson(var value: TValue; const index: ISuperObject; field: TRttiField): ISuperObject;
   procedure ToInt64;
   begin
     Result := TSuperObject.Create(SuperInt(Value.AsInt64));
@@ -7012,12 +7012,12 @@ function TSuperRttiContext.ToJson(var value: TValue; const index: ISuperObject; 
             begin
               if (GetFieldName(f) = 'FItems') then
               begin
-                Result := ToJson(v, index, v.GetArrayLength);
+                Result := ToJson(v, index);
               end;
               Continue;
             end;
 
-            jsonValue := ToJson(v, index, -1, f);
+            jsonValue := ToJson(v, index, f);
             if jsonValue <> nil then
             begin
               Result.AsObject[GetFieldName(f)] := jsonValue;
@@ -7108,16 +7108,9 @@ function TSuperRttiContext.ToJson(var value: TValue; const index: ISuperObject; 
   var
     i: Integer;
     v: TValue;
-    count: integer;
   begin
     Result := TSuperObject.Create(stArray);
-    count := Value.GetArrayLength;
-    // If `value` is a TList the SIZE of the list will be returned instead
-    // of the item count.
-    // I made a temp fix here by parsing the _listCount parameter.
-    if _listCount > -1 then
-      count := _listCount;
-    for i := 0 to count - 1 do
+    for i := 0 to Value.GetArrayLength - 1 do
     begin
       v := Value.GetArrayElement(i);
       if not v.IsEmpty then

--- a/src/RestClient.pas
+++ b/src/RestClient.pas
@@ -7,7 +7,7 @@ interface
 uses Classes, SysUtils, HttpConnection,
      RestUtils, RestJsonUtils,
      {$IFDEF SUPPORTS_GENERICS}
-     Generics.Collections, Rtti,
+     Generics.Collections, Rtti, TypInfo,
      {$ELSE}
      Contnrs, OldRttiUnMarshal,
      {$ENDIF}

--- a/unittest/TestSuperobject.pas
+++ b/unittest/TestSuperobject.pas
@@ -16,6 +16,7 @@ type
     procedure SetUp; override;
   published
     procedure TestNullInt;
+    procedure TestList;
   end;
 
   TTestInt = class(TObject)
@@ -58,6 +59,23 @@ end;
 procedure TTestSuperObjectUnMarshal.TearDown;
 begin
   inherited;
+end;
+
+procedure TTestSuperObjectUnMarshal.TestList;
+var
+  list: TList<integer>;
+  s: string;
+begin
+  list := TList<integer>.create;
+  try
+    list.Add(1);
+    list.Add(2);
+    list.Add(3);
+    s := list.ToJson().AsJSon();
+    checkEquals('[1,2,3]', s);
+  finally
+    list.Free;
+  end;
 end;
 
 procedure TTestSuperObjectUnMarshal.TestNullInt;


### PR DESCRIPTION
Commit a80d83b2420b55772677421f41db251a23bb28d9 removed part of my temporary fix for a TList serialization bug in superobject.
A test has been added that checks for it.

The problem: `GetArrayLength` returns the SIZE not the number of items in the TList. It works fine for a normal array. So if the list contains 3 items `GetArrayLength` will return 4! [1, 2, 3, 0].

I'm drawing a blank on how to fix it so any ideas is appreciated.