### PR TITLE
Handling null-values in float-field

### DIFF
--- a/lib/superobject/superobject.pas
+++ b/lib/superobject/superobject.pas
@@ -6555,6 +6555,11 @@ function TSuperRttiContext.FromJson(TypeInfo: PTypeInfo; const obj: ISuperObject
         end;
         Result := True;
       end;
+    stNull:
+      begin
+        TValue.Make(nil, TypeInfo, Value);
+        Result := True;
+      end;
     stString:
       begin
           fmtSettings.DateSeparator := '-';


### PR DESCRIPTION
I want to receive the Json-element
      "customfield_11111":13.0,
into the structure
     customfield_11111: double; // jobsize
That works fine, but sometimes I receive
"customfield_11111":null,
and get a ”Marshalling error”. With this correction I am able to receive a zero instead of a marshalling error.