### PR TITLE
java-rest-server fail to build

### DIFF
--- a/java-rest-server/pom.xml
+++ b/java-rest-server/pom.xml
@@ -53,8 +53,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.8</source>
+						<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Hi @All, with current pom.xml java-rest-server doesn't get built with JDK 1.8.  Reporting:

> Source option 6 is no longer supported. Use 7 or later.

This small change fixes problem.