### PR TITLE
TResource.Delete() method change request.

### DIFF
--- a/java-rest-server/src/main/java/br/com/fabriciodev/rest/controller/JsonController.java
+++ b/java-rest-server/src/main/java/br/com/fabriciodev/rest/controller/JsonController.java
@@ -58,6 +58,7 @@ public class JsonController {
 	@DELETE
 	@Path("person")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_XML })
 	public void removePerson(Person person) {
 		assert(person != null);
 		System.out.println("DELETE " + person);

--- a/java-rest-server/src/main/java/br/com/fabriciodev/rest/controller/PeopleController.java
+++ b/java-rest-server/src/main/java/br/com/fabriciodev/rest/controller/PeopleController.java
@@ -93,6 +93,7 @@ public class PeopleController {
 	@DELETE
 	@Path("person")
 	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_XML })
 	public void removePerson(Person person) {
 		repository.remove(person.getId());
 

--- a/src/HttpConnectionIndy.pas
+++ b/src/HttpConnectionIndy.pas
@@ -10,7 +10,6 @@ uses IdHTTP, HttpConnection, Classes, RestUtils, IdCompressorZLib, SysUtils,
 type
   TIdHTTP = class(idHTTP.TIdHTTP)
   public
-    procedure Delete(AURL: string);
     procedure Patch(AURL: string; ASource, AResponseContent: TStream);
   end;
 
@@ -144,7 +143,7 @@ var
 begin
   try
     FIdHttp.Request.Source := AContent;
-    FIdHttp.Delete(AUrl);
+    FIdHttp.Delete(AUrl, AResponse);
   except
     on E: EIdHTTPProtocolException do
     begin
@@ -424,18 +423,6 @@ end;
 procedure THttpConnectionIndy.SetVerifyCert(const Value: boolean);
 begin
   FVerifyCert := Value;
-end;
-
-{ TIdHTTP }
-
-procedure TIdHTTP.Delete(AURL: string);
-begin
-  try
-    DoRequest(Id_HTTPMethodDelete, AURL, Request.Source, nil, []);
-  except
-    on E: EIdHTTPProtocolException do
-      raise EHTTPError.Create(e.Message, e.ErrorMessage, e.ErrorCode);
-  end;
 end;
 
 procedure TIdHTTP.Patch(AURL: string; ASource, AResponseContent: TStream);

--- a/src/RestClient.pas
+++ b/src/RestClient.pas
@@ -212,7 +212,7 @@ type
     function Patch(Content: TStream; ResultClass: TClass): TObject;overload;
     function Patch(Entity: TObject; ResultClass: TClass): TObject;overload;
 
-    procedure Delete();overload;
+    function Delete: string; overload;
     procedure Delete(Entity: TObject);overload;
 
     {$IFDEF SUPPORTS_ANONYMOUS_METHODS}
@@ -738,9 +738,9 @@ begin
   FHeaders := TStringList.Create;
 end;
 
-procedure TResource.Delete();
+function TResource.Delete: string;
 begin
-  FRestClient.DoRequest(METHOD_DELETE, Self);
+  Result := FRestClient.DoRequest(METHOD_DELETE, Self);
 end;
 
 procedure TResource.Delete(Entity: TObject);


### PR DESCRIPTION
Hi, @fabriciocolombo and team. Thank you for your work. I'm Igor and I'm a Delphi dev. Currently I'm working on API integration which returns content on DELETE method.
This PR:

 * adds possibility to handle API response for Delete.
 * fixes situation when http errors (for example 404) don't trigger Client OnError.
 * updates java-rest-server controllers for proper working with unit tests. 

Because I'm assuming absense of "@produces" on DELETE methods in controllers is a bad server side design. It should not be hacked on client side as we did.

Please consider PR #135. It fixes java-rest-server compilation for JDK 1.8.