### PR TITLE
add conditional define for delphi 2006 on the set default encryption protocol…

### DIFF
--- a/src/HttpConnectionIndy.pas
+++ b/src/HttpConnectionIndy.pas
@@ -109,8 +109,9 @@ begin
   ssl := TIdSSLIOHandlerSocketOpenSSL.Create(FIdHttp);
   ssl.OnVerifyPeer := IdSSLIOHandlerSocketOpenSSL1VerifyPeer;
 
-  {$if defined(DELPHI_7) or defined(DELPHI_2007) or
-       defined(DELPHI_2009) or defined(DELPHI_2010)}
+  {$if defined(DELPHI_7)    or defined(DELPHI_2006) or
+       defined(DELPHI_2007) or defined(DELPHI_2009) or 
+       defined(DELPHI_2010) }
     ssl.SSLOptions.Method := sslvTLSv1;
   {$ifend}
 


### PR DESCRIPTION
Delphi 2006 is lacking on the project. 
There was a need to use the conditional define for it to set tls 1.0 when using delphi 2006